### PR TITLE
Update chapter_02_the_series_object.ipynb

### DIFF
--- a/chapter_02_the_series_object/chapter_02_the_series_object.ipynb
+++ b/chapter_02_the_series_object/chapter_02_the_series_object.ipynb
@@ -1921,7 +1921,7 @@
    "outputs": [],
    "source": [
     "cities = pd.Series(\n",
-    "    data = [\"San Francisco\", \"Los Angeles\", \"Las  Vegas\", np.nan]\n",
+    "    data = [\"San Francisco\", \"Los Angeles\", \"Las Vegas\", np.nan]\n",
     ")"
    ]
   },


### PR DESCRIPTION
extra space makes `"Las Vegas" in ...` "wrongly" execute "False"